### PR TITLE
Rename MyBaseMat -> MyTriangulizedBaseMat

### DIFF
--- a/gap/algnq/eggert.gi
+++ b/gap/algnq/eggert.gi
@@ -4,7 +4,7 @@ BindGlobal( "PthPowers", function( T )
     p := Characteristic(T.fld);
     I := IdentityMat(T.dim, T.fld);
     B := List(I, x -> PowerByTable( T, x, p ));
-    return MyBaseMat(B);
+    return MyTriangulizedBaseMat(B);
 end );
 
 BindGlobal( "Eggert", function(d, c, p)
@@ -51,7 +51,7 @@ BindGlobal( "FindIdeal", function(N, I)
         m := Filtered(m, x -> IsBool(SolutionMat(L, x)));
         m := List(m, x -> x * B);
         if Length(m) = 0 then return J; fi;
-        J := MyBaseMat(Concatenation(J, m));
+        J := MyTriangulizedBaseMat(Concatenation(J, m));
         B := BaseSteinitzVectors(IdentityMat(N.dim, N.fld), J).factorspace;
         K := InduceModule(M, B, J);
         L := InduceIdeal(I, B, J);

--- a/gap/autiso/initial.gi
+++ b/gap/autiso/initial.gi
@@ -28,7 +28,7 @@ BindGlobal( "InitAutomGroup", function( Tab )
         inv := [1..Length(s)];
         for i in [1..Length(s)] do
             ind := Filtered([1..Length(m)], x -> m[x] = s[i]);
-            inv[i] := MyBaseMat( v{ind} );
+            inv[i] := MyTriangulizedBaseMat( v{ind} );
         od;
 
         # create a chain from invariant subspaces

--- a/gap/cfstab/check.gi
+++ b/gap/cfstab/check.gi
@@ -50,7 +50,7 @@ BindGlobal( "TestSubspaceCanoForm", function( d, F )
 
     # take a random subspace
     l := Random([1..d]);
-    b := MyBaseMat(RandomMat( l, d, F ));
+    b := MyTriangulizedBaseMat(RandomMat( l, d, F ));
     Print("got subspace of dim ",Length(b),"\n");
 
     # take a pcgs for a random subgroup of U
@@ -71,7 +71,7 @@ BindGlobal( "TestSubspaceCanoForm", function( d, F )
     for i in [1..10] do
         Print(i," th check \n");
         v := MappedVector( Exponents(Random(V)), U!.mats );
-        c := MyBaseMat( b * v );
+        c := MyTriangulizedBaseMat( b * v );
         f := SubspaceCanonicalForm( m, o, c, F );
         if f.cano <> r.cano then Error("no cano form"); fi;
         if Length(f.stab) <> Length(r.stab) then Error("wrong stab"); fi;

--- a/gap/cfstab/general.gi
+++ b/gap/cfstab/general.gi
@@ -37,11 +37,14 @@ BindGlobal( "CoeffsMinimalElement", function( vec, base )
     return IntVecFFE(cof * mat.coeffs);
 end );
 
-BindGlobal( "MyBaseMat", function(mat)
+# The following function behaves like `TriangulizedMat`, the only
+# difference is that any zero rows are dropped, i.e., as base of
+# the row-space is returned (like `BaseMat` does, but there it
+# is not necessarily triangular)
+BindGlobal( "MyTriangulizedBaseMat", function(mat)
     local new, j;
     if Length(mat) = 0 then return mat; fi;
-    new := StructuralCopy(mat);
-    TriangulizeMat(new);
+    new := TriangulizedMat(mat);
     j := Position(new, 0*new[1]);
     if IsBool(j) then return new; fi;
     return new{[1..j-1]};

--- a/gap/cfstab/orbstab.gi
+++ b/gap/cfstab/orbstab.gi
@@ -42,7 +42,7 @@ BindGlobal( "BlockCanonicalForm", function( G, U )
         for i in [1..Length(G.glAutos)] do
 
             # compute image 
-            V := MyBaseMat( orbit[k] * G.glAutos[i][2] );
+            V := MyTriangulizedBaseMat( orbit[k] * G.glAutos[i][2] );
             W := SubspaceCanonicalForm( G.agAutos, G.one, V, F );
             j := Position( orbit, W.cano );
 
@@ -125,7 +125,7 @@ BindGlobal( "BlockCanonicalFormBySeries", function(G, U, ser)
                 h := NaturalHomomorphismBySubspaceOntoFullRowSpace( S, T );
 
                 # get point
-                W := MyBaseMat(List(W, x -> Image( h, x )));
+                W := MyTriangulizedBaseMat(List(W, x -> Image( h, x )));
 
                 # add action on layer
                 for j in [1..Length(G.glAutos)] do
@@ -144,7 +144,7 @@ BindGlobal( "BlockCanonicalFormBySeries", function(G, U, ser)
 
                 # adjust canonical form
                 tv := tv * cf.tran[1];
-                pt := MyBaseMat( U * tv[2] );
+                pt := MyTriangulizedBaseMat( U * tv[2] );
 
                 # cut off action on layer
                 for j in [1..Length(G.glAutos)] do
@@ -188,7 +188,7 @@ BindGlobal( "HybridMatrixCanoForm", function( G, U )
     od;
 
     # adjust point
-    W := MyBaseMat( U*c );
+    W := MyTriangulizedBaseMat( U*c );
 
     # compute stabilizer
     if (Length(G.agAutos) = 0 and G.glOrder > MIP_GLLIMIT) or USE_MSERS then 
@@ -201,7 +201,7 @@ BindGlobal( "HybridMatrixCanoForm", function( G, U )
 
     # set up result - translate to old basis
     C := rec();
-    C.cf := MyBaseMat( V.cano*b );
+    C.cf := MyTriangulizedBaseMat( V.cano*b );
     C.tv := DirectProductElement([V.tran[1], c*V.tran[2]*b]);
     C.ti := C.tv^-1;
 
@@ -213,7 +213,7 @@ BindGlobal( "HybridMatrixCanoForm", function( G, U )
         for g in G.agAutos do
             if not IsInvariantAssert(C.cf, [c*g[2]*b]) then Error("no ag-stab"); fi;
         od;
-        if not MyBaseMat(U*C.tv[2]) = C.cf then Error("no trans"); fi;
+        if not MyTriangulizedBaseMat(U*C.tv[2]) = C.cf then Error("no trans"); fi;
     fi;
 
     # return canonical form 

--- a/gap/cfstab/pgroup.gi
+++ b/gap/cfstab/pgroup.gi
@@ -118,7 +118,7 @@ BindGlobal( "SubspaceCanonicalForm", function( pcgs, id, base, F )
 
             stab := c.stab;
             tran := c.tran;
-            cano := MyBaseMat( base * tran[2] );
+            cano := MyTriangulizedBaseMat( base * tran[2] );
 
         # the others 
         elif Length(stab) > 0 then 
@@ -134,13 +134,13 @@ BindGlobal( "SubspaceCanonicalForm", function( pcgs, id, base, F )
             # translate result
             stab := c.stab;
             tran := tran * c.tran;
-            cano := MyBaseMat( base * tran[2] );
+            cano := MyTriangulizedBaseMat( base * tran[2] );
         fi;
 
     od;
 
     if CHECK_CNF then 
-        if not ForAll( stab, x -> cano = MyBaseMat(cano*x[2]) ) then 
+        if not ForAll( stab, x -> cano = MyTriangulizedBaseMat(cano*x[2]) ) then 
             Error("stabilizer does not stabilize in subspace cano form");
         fi;
     fi;

--- a/gap/grpalg/detbins.gi
+++ b/gap/grpalg/detbins.gi
@@ -262,7 +262,7 @@ BindGlobal( "LinearPowersBySeries", function( A, bases )
         w := StructuralCopy(bases[i]);
         while Length(w) > 0 do
             w := List(w, x -> (x*Basis(A))^p);
-            w := MyBaseMat(List(w, x -> Coefficients(Basis(A),x)));
+            w := MyTriangulizedBaseMat(List(w, x -> Coefficients(Basis(A),x)));
             Add(r[i], w);
         od;
         Unbind(r[i][Length(r[i])]);
@@ -384,7 +384,7 @@ BindGlobal( "PowerMapAbelian", function(A)
                 #Print("  consider ",i," mod ",j," with ",k,"th powers \n");
 
                 # take image
-                b := MyBaseMat( Concatenation( r[i][k], bas[j] ) );
+                b := MyTriangulizedBaseMat( Concatenation( r[i][k], bas[j] ) );
 
                 # relate to comms
                 bcm := RankMat(Concatenation( cm, b ));


### PR DESCRIPTION
... and also add a comment explaining what it does. This renaming avoids
a clash with Liepring's function of the same name (we also have a
workaround in the latest liepring, but for the sake of people who only
update one of the two packages, it seems prudent to add workaround in
both)
