### PR TITLE
Require GAP 4.11

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,7 +31,6 @@ jobs:
           - '4.13'
           - '4.12'
           - '4.11'
-          - '4.10'
 
     steps:
       - uses: actions/checkout@v6

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -123,7 +123,7 @@ PackageDoc := rec(
 
 
 Dependencies := rec(
-  GAP := ">=4.10",
+  GAP := ">=4.11",
   NeededOtherPackages := [["Polycyclic", ">=1.0"], ["LAGUNA", ">=3.8.0"]],
   SuggestedOtherPackages := [],
   ExternalConditions := []


### PR DESCRIPTION
This package uses `IdGroupsAvailable` which was added in SmallGrps 1.4; but GAP 4.10 only has SmallGrps 1.3 (see for example [this CI log](https://github.com/gap-packages/modisom/actions/runs/20955364409/job/60218554499#step:5:184) which shows the resulting failure)


This was hidden until today because we used the "old" CI setup here, which tested a version of GAP 4.10 that was never shipped to users, with newer packages than what GAP 4.10.2 (the last release of the 4.10.x series) bundled. With the improved CI setup, we are now actually testing against GAP 4.10.2.