### PR TITLE
Make SmallGrp an explicit dependency

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -124,7 +124,8 @@ PackageDoc := rec(
 
 Dependencies := rec(
   GAP := ">=4.11",
-  NeededOtherPackages := [["Polycyclic", ">=1.0"], ["LAGUNA", ">=3.8.0"]],
+  NeededOtherPackages := [["Polycyclic", ">=1.0"], ["LAGUNA", ">=3.8.0"],
+                          ["SmallGrp", ">=1.4"]],
   SuggestedOtherPackages := [],
   ExternalConditions := []
 ),


### PR DESCRIPTION
ModIsom studies the modular isomorphism problem for group algebras of the
groups of order p^n, and represents those groups by their id in the small
groups library: MIPBinsByGT and friends compute bins which are lists of
such ids, and turn them back into groups via SmallGroup(p^n, id). Five of
the files read by read.g use SmallGroup, IdGroup, IdSmallGroup,
NumberSmallGroups or IdGroupsAvailable, and the manual examples in
tst/manexamples.tst name their groups the same way. Without the SmallGrp
package the test suite failed with 43 differences:

    Error, the Small Groups library is required but not installed

The required version is 1.4, which is the first one providing
IdGroupsAvailable, used in gap/grpalg/chkbins.gi. That is satisfied by
every GAP release supported by ModIsom, as GAP 4.11 already shipped
SmallGrp 1.4.2.

See https://github.com/gap-system/gap/issues/2434

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
